### PR TITLE
FEATURE: Remove xml:space attribute

### DIFF
--- a/Resources/Private/Fusion/Icon.fusion
+++ b/Resources/Private/Fusion/Icon.fusion
@@ -16,7 +16,6 @@ prototype(Sitegeist.Stampede:Icon) < prototype(Neos.Fusion:Component) {
                     xmlns="http://www.w3.org/2000/svg"
                     xmlns:xlink="http://www.w3.org/1999/xlink"
                     viewBox="0 0 512 512"
-                    xml:space="preserve"
                     class={props.class}
                     style={props.style}
                 >


### PR DESCRIPTION
The `xml:space` attribute is deprecated since SVG 2
This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes.

More informations:
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xml:space