### PR TITLE
BUGFIX: Relax condition for inline/sprite icon

### DIFF
--- a/Resources/Private/Fusion/Icon.fusion
+++ b/Resources/Private/Fusion/Icon.fusion
@@ -10,7 +10,7 @@ prototype(Sitegeist.Stampede:Icon) < prototype(Neos.Fusion:Component) {
     renderer = Neos.Fusion:Case {
         @if.has = ${props.collection && props.icon}
         sprite {
-            condition = ${props.inline == false}
+            condition = ${!props.inline}
             renderer = afx`
                 <svg
                     version="1.1"
@@ -29,7 +29,7 @@ prototype(Sitegeist.Stampede:Icon) < prototype(Neos.Fusion:Component) {
         }
 
         inline {
-            condition = ${props.inline == true}
+            condition = true
             renderer = afx`
                 <Neos.Fusion:Augmenter
                     class={props.class}


### PR DESCRIPTION
Currently, `inline = null` leads to that no icon get rendered at all. The `inline` condition is simply set to `true`, at there is no need for further checks. If someone wants to integrate another way to show the icon (for example with an included sprite on the page, it is possible to prepend it with the `@position` property.