### PR TITLE
BUGFIX: Fix default value for arguments

### DIFF
--- a/Classes/DataSource/IconDataSource.php
+++ b/Classes/DataSource/IconDataSource.php
@@ -27,7 +27,7 @@ class IconDataSource extends AbstractDataSource
      * @param array $arguments Additional arguments (key / value)
      * @return array JSON serializable data
      */
-    public function getData(NodeInterface $node = null, array $arguments)
+    public function getData(NodeInterface $node = null, array $arguments = [])
     {
         $result = [];
 


### PR DESCRIPTION
This fix makes stampede works under Neos 5.1. 
Resolve issue #6 