### PR TITLE
FEATURE: Add public cache control header to the response of the spritesheet controller

### DIFF
--- a/Classes/Controller/SvgController.php
+++ b/Classes/Controller/SvgController.php
@@ -58,6 +58,10 @@ class SvgController extends ActionController
             $this->svgSpriteCache->set($collection, $result);
         }
 
+        if ($this->configuration['publicCacheLifetime']) {
+            $this->response->addHttpHeader('Cache-Control', 'public, max-age=' . $this->configuration['publicCacheLifetime']);
+        }
+
         if ($result) {
             $this->response->setContentType('image/svg+xml');
             return $result;

--- a/Configuration/Development/Settings.yaml
+++ b/Configuration/Development/Settings.yaml
@@ -1,3 +1,4 @@
 Sitegeist:
   Stampede:
     enableCache: false
+    publicCacheLifetime: null

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,8 +1,9 @@
 Sitegeist:
   Stampede:
     enableCache: true
+    publicCacheLifetime: 86400
     collections: []
-            
+
   Silhouettes:
     properties:
       stampede:

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ Sitegeist:
     enableCache: false
 ```  
 
+The svg sprite sheet will get a cache-control header in Production context. You can adjust the value or disable this
+via setting:
+
+```yaml
+Sitegeist:
+  Stampede:
+      publicCacheLifetime: 86400
+```  
+
 A custom data source is included to allow editors to select icons in the Neos Inspector: 
 ```yaml
 'Vendor.Site:NodeType': 


### PR DESCRIPTION
The svg sprite sheet will get a cache-control header in Production context. You can adjust the value or disable this
via setting:

```yaml
Sitegeist:
  Stampede:
      publicCacheLifetime: 86400
```