### PR TITLE
FEATURE: Option sort icons by name

### DIFF
--- a/Classes/Domain/IconCollection.php
+++ b/Classes/Domain/IconCollection.php
@@ -39,18 +39,13 @@ class IconCollection
                 $label = $name;
                 $this->icons[$name] = new Icon($name, $label, $svgFile);
             }
+            ksort($this->icons);
         } elseif (array_key_exists('items', $collectionConfiguration) && is_array($collectionConfiguration['items'])) {
             foreach ($collectionConfiguration['items'] as $name => $itemConfiguration) {
                 $label = $itemConfiguration['label'] ?? $name;
                 if (array_key_exists('path', $itemConfiguration) && file_exists( $itemConfiguration['path'])) {
                     $this->icons[$name] = new Icon($name, $label, $itemConfiguration['path']);
                 }
-            }
-        }
-        if(array_key_exists('ordering', $collectionConfiguration)) {
-            switch ($collectionConfiguration['ordering']) {
-                case 'numerical':
-                    ksort($this->icons);
             }
         }
     }

--- a/Classes/Domain/IconCollection.php
+++ b/Classes/Domain/IconCollection.php
@@ -47,6 +47,12 @@ class IconCollection
                 }
             }
         }
+        if(array_key_exists('ordering', $collectionConfiguration)) {
+            switch ($collectionConfiguration['ordering']) {
+                case 'numerical':
+                    ksort($this->icons);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
Icons from a `path`-collection was random. This change adds sorting by name which gives a predictable order.
Collections defined as a list of `items` are not affected as those can be ordered in the configuration.